### PR TITLE
fix: compatibility with zkSync

### DIFF
--- a/tests/GC_VotingConfigs.t.sol
+++ b/tests/GC_VotingConfigs.t.sol
@@ -15,9 +15,9 @@ import {Errors} from '../src/contracts/libraries/Errors.sol';
 import {IBaseVotingStrategy} from '../src/interfaces/IBaseVotingStrategy.sol';
 
 contract GCore_VotingConfigsTest is Test {
-  address public constant OWNER = address(123);
-  address public constant GUARDIAN = address(1234);
-  address public constant ADMIN = address(12345);
+  address public constant OWNER = address(65536+123);
+  address public constant GUARDIAN = address(65536+1234);
+  address public constant ADMIN = address(65536+12345);
   address public constant CROSS_CHAIN_CONTROLLER = address(123456);
   address public constant SAME_CHAIN_VOTING_MACHINE = address(1234567);
   address public constant EXECUTION_PORTAL = address(12345678);

--- a/tests/GovernanceCore.t.sol
+++ b/tests/GovernanceCore.t.sol
@@ -16,9 +16,9 @@ import {Errors} from '../src/contracts/libraries/Errors.sol';
 import {IBaseVotingStrategy} from '../src/interfaces/IBaseVotingStrategy.sol';
 
 contract GovernanceCoreTest is Test {
-  address public constant OWNER = address(123);
-  address public constant GUARDIAN = address(1234);
-  address public constant ADMIN = address(12345);
+  address public constant OWNER = address(65536+123);
+  address public constant GUARDIAN = address(65536+1234);
+  address public constant ADMIN = address(65536+12345);
   address public constant CROSS_CHAIN_CONTROLLER = address(123456);
   address public constant SAME_CHAIN_VOTING_MACHINE = address(1234567);
   address public constant EXECUTION_PORTAL = address(12345678);

--- a/tests/GovernanceCore.t.sol
+++ b/tests/GovernanceCore.t.sol
@@ -2051,6 +2051,11 @@ contract GovernanceCoreTest is Test {
     );
     skip(config.coolDownBeforeVotingStart + 1);
     vm.mockCall(
+      VOTING_PORTAL,
+      abi.encodeWithSelector(IVotingPortal.forwardStartVotingMessage.selector),
+      abi.encode()
+    );
+    vm.mockCall(
       VOTING_STRATEGY,
       abi.encodeWithSelector(
         IGovernancePowerStrategy.getFullPropositionPower.selector,
@@ -2121,6 +2126,16 @@ contract GovernanceCoreTest is Test {
         address(this)
       ),
       abi.encode(10000000 ether)
+    );
+    vm.mockCall(
+      VOTING_PORTAL,
+      abi.encodeWithSelector(
+        IVotingPortal.forwardStartVotingMessage.selector,
+        0,
+        0,
+        votingConfigLvl1.votingDuration
+      ),
+      abi.encode()
     );
     hoax(VOTING_PORTAL);
     governance.queueProposal(proposalId, forVotes, againstVotes);

--- a/tests/MessageSizes.t.sol
+++ b/tests/MessageSizes.t.sol
@@ -8,9 +8,9 @@ import '../src/contracts/voting/interfaces/IVotingMachineWithProofs.sol';
 import {PayloadsControllerUtils} from '../src/contracts/payloads/PayloadsControllerUtils.sol';
 
 contract MessageSizesTest is Test {
-  address public constant ORIGIN = address(123);
-  address public constant DESTINATION = address(1234);
-  address public constant VOTER = address(12345);
+  address public constant ORIGIN = address(65536+123);
+  address public constant DESTINATION = address(65536+1234);
+  address public constant VOTER = address(65536+12345);
   address public constant PAYLOADS_CONTROLLER = address(123456);
   uint256 public constant ORIGIN_CHAIN_ID = ChainIds.ETHEREUM;
   uint256 public constant DESTINATION_CHAIN_ID = ChainIds.POLYGON;

--- a/tests/VotingPortal.t.sol
+++ b/tests/VotingPortal.t.sol
@@ -10,9 +10,9 @@ import {ICrossChainReceiver} from 'aave-delivery-infrastructure/contracts/interf
 import {Errors} from '../src/contracts/libraries/Errors.sol';
 
 contract VotingPortalTest is Test {
-  address public constant CROSS_CHAIN_CONTROLLER = address(123);
-  address public constant GOVERNANCE = address(1234);
-  address public constant VOTING_MACHINE = address(12345);
+  address public constant CROSS_CHAIN_CONTROLLER = address(65536+123);
+  address public constant GOVERNANCE = address(65536+1234);
+  address public constant VOTING_MACHINE = address(65536+12345);
   uint128 public constant GAS_LIMIT = 600000;
 
   uint256 public VOTING_MACHINE_CHAIN_ID;

--- a/tests/payloads/Executor.t.sol
+++ b/tests/payloads/Executor.t.sol
@@ -8,7 +8,7 @@ import {PayloadTest} from './utils/PayloadTest.sol';
 import {Errors} from '../../src/contracts/libraries/Errors.sol';
 
 contract ExecutorTest is Test {
-  address public constant TARGET = address(12345);
+  address public constant TARGET = address(65536+12345);
   uint256 public constant VALUE = 0;
   string public constant SIGNATURE = 'execute()';
   bytes public constant DATA = bytes('');

--- a/tests/payloads/PayloadsController.t.sol
+++ b/tests/payloads/PayloadsController.t.sol
@@ -10,8 +10,8 @@ import {TransparentProxyFactory} from 'solidity-utils/contracts/transparent-prox
 import {Errors} from '../../src/contracts/libraries/Errors.sol';
 
 contract PayloadsControllerTest is Test {
-  address constant ADMIN = address(123);
-  address constant GUARDIAN = address(1234);
+  address constant ADMIN = address(65536+123);
+  address constant GUARDIAN = address(65536+1234);
   address public constant MESSAGE_ORIGINATOR = address(1234190812);
   address public constant CROSS_CHAIN_CONTROLLER = address(123456);
 

--- a/tests/payloads/PayloadsControllerCore.t.sol
+++ b/tests/payloads/PayloadsControllerCore.t.sol
@@ -25,8 +25,8 @@ contract PayloadsControllerMock is PayloadsControllerCore {
 }
 
 contract PayloadsControllerCoreTest is Test {
-  address public constant ADMIN = address(123);
-  address public constant GUARDIAN = address(1234);
+  address public constant ADMIN = address(65536+123);
+  address public constant GUARDIAN = address(65536+1234);
   address public constant ORIGIN_FORWARDER = address(123456);
   address public constant PAYLOAD_PORTAL = address(987312);
   uint256 public constant YES_THRESHOLD = 1;

--- a/tests/voting/VotingMachine.t.sol
+++ b/tests/voting/VotingMachine.t.sol
@@ -54,9 +54,9 @@ contract VotingMachineMock is VotingMachine {
 }
 
 contract VotingMachineTest is Test {
-  address public constant CROSS_CHAIN_CONTROLLER = address(123);
-  address public constant L1_VOTING_PORTAL = address(1234);
-  address public constant GOVERNANCE = address(12345);
+  address public constant CROSS_CHAIN_CONTROLLER = address(65536+123);
+  address public constant L1_VOTING_PORTAL = address(65536+1234);
+  address public constant GOVERNANCE = address(65536+12345);
   uint256 L1_VOTING_PORTAL_CHAIN_ID;
   uint256 public constant GAS_LIMIT = 600000;
 

--- a/tests/voting/VotingStrategy.t.sol
+++ b/tests/voting/VotingStrategy.t.sol
@@ -8,7 +8,7 @@ import {Errors} from '../../src/contracts/libraries/Errors.sol';
 import {BaseProofTest, VotingStrategyTest as VSTest} from '../utils/BaseProofTest.sol';
 
 contract VotingStrategyTest is BaseProofTest {
-  address constant DATA_WAREHOUSE = address(123);
+  address constant DATA_WAREHOUSE = address(65536+123);
 
   function setUp() public {
     votingStrategy = new VSTest(DATA_WAREHOUSE);

--- a/tests/voting/VotingStrategyStkAave.t.sol
+++ b/tests/voting/VotingStrategyStkAave.t.sol
@@ -9,7 +9,7 @@ import {VotingStrategy, IVotingStrategy, IBaseVotingStrategy} from '../../src/co
 import {SlotUtils} from '../../src/contracts/libraries/SlotUtils.sol';
 
 contract VotingStrategyStkAaveTest is Test {
-  address DATA_WAREHOUSE = address(123);
+  address DATA_WAREHOUSE = address(65536+123);
   bytes32 constant BLOCK_HASH =
     0x0a7c36db26203276b9430a46faaba9ce76732c5b7c11ef07b39e81a2690591b7;
   address constant VOTER = 0x6D603081563784dB3f83ef1F65Cc389D94365Ac9;

--- a/tests/voting/votingMachineWithProofs.t.sol
+++ b/tests/voting/votingMachineWithProofs.t.sol
@@ -69,7 +69,7 @@ contract VotingMachineWithProofsTest is Test {
   bytes32 BLOCK_HASH =
     0xf656a10e5d825e287890cc430cf1bac2364b756e09e19b6fa3a72ec844ba2f44;
   address VOTER = 0x6D603081563784dB3f83ef1F65Cc389D94365Ac9;
-  address public constant GOVERNANCE = address(12345);
+  address public constant GOVERNANCE = address(65536+12345);
 
   IDataWarehouse dataWarehouse;
   IVotingStrategy votingStrategy;
@@ -1559,7 +1559,7 @@ contract VotingMachineWithProofsTest is Test {
         abi.encode(
           votingMachine.VOTE_SUBMITTED_BY_REPRESENTATIVE_TYPEHASH(),
           2,
-          address(1234),
+          address(65536+1234),
           signer,
           true,
           _getVotingAssetsWithSlotHash(votingAssetsWithSlot)


### PR DESCRIPTION
This PR addresses a few discrepancies found when running the test suite on ZkSync, with the ultimate goal of making AAVE protocol compatible with the network.

### The main discrepancies include:
1. Reserved Addresses: In ZkSync, addresses below 2^16 are reserved and using them during testing can lead to failures or slow down the process due to the necessity of excluding them. The proposed solution is to introduce a fuzz config flag called no_zksync_reserved_addresses that offsets system-generated reserved addresses by 65536, allowing them to fall within the valid address range. This avoids using prop_filter and maps invalid addresses to the valid address range, ensuring minimal impact on fuzzer performance.

### Test suite specific discrepancies:
1. The GovernanceCore test suite needs to be updated to properly mock function calls and return values, ensuring compatibility with ZkVM.

By addressing these issues, we aim to facilitate discussions on the changes made and their reasons, ultimately leading to Aave's successful implementation on the ZkSync network.

Contributors
@HermanObst, @Jrigada, @Karrq, @nbaztec

/cc @Deniallugo @dutterbutter