### PR TITLE
fix: allow owner to change delay on PPC

### DIFF
--- a/.github/workflows/certora-review-execution-chain.yml
+++ b/.github/workflows/certora-review-execution-chain.yml
@@ -26,11 +26,12 @@ jobs:
       contents: read
       statuses: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: Certora/certora-run-action@v1
+      - uses: Certora/certora-run-action@v2
         with:
           cli-version: 7.28.0
           configurations: |-

--- a/.github/workflows/certora-review-mainnet.yml
+++ b/.github/workflows/certora-review-mainnet.yml
@@ -26,11 +26,12 @@ jobs:
       contents: read
       statuses: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: Certora/certora-run-action@v1
+      - uses: Certora/certora-run-action@v2
         with:
           cli-version: 7.28.0
           configurations: |-

--- a/.github/workflows/certora-review-voting-chain.yml
+++ b/.github/workflows/certora-review-voting-chain.yml
@@ -26,16 +26,18 @@ jobs:
       contents: read
       statuses: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: Certora/certora-run-action@v1
+      - uses: Certora/certora-run-action@v2
         with:
           cli-version: 7.28.0
           configurations: |-
             security/certora/confs/voting/verifyLegality.conf --rule createdVoteHasNonZeroHash  votedPowerIsImmutable  onlyValidProposalCanChangeTally  legalVote  method_reachability
-            security/certora/confs/voting/verifyMisc.conf
+            security/certora/confs/voting/verifyMisc.conf --exclude_rule submitTripleProofVerification
+            security/certora/confs/voting/verifyMisc.conf --rule submitTripleProofVerification
             security/certora/confs/voting/verifyPower_summary.conf --rule onlyThreeTokens method_reachability
             security/certora/confs/voting/verifyProposal_config.conf --rule startedProposalHasConfig  createdProposalHasRoots  proposalHasNonzeroDuration newProposalUnusedId configIsImmutable  getProposalsConfigsDoesntRevert  method_reachability 
             security/certora/confs/voting/verifyProposal_states.conf --rule startsBeforeEnds  startsStrictlyBeforeEnds  proposalLegalStates  proposalMethodStateTransitionCompliance  proposalTimeStateTransitionCompliance  proposalIdIsImmutable  proposalImmutability  startedProposalHasConfig  proposalHasNonzeroDuration method_reachability 

--- a/docs/permissioned-payloads-controller-overview.md
+++ b/docs/permissioned-payloads-controller-overview.md
@@ -8,7 +8,7 @@ At launch it will have permissions to change the LM programs for Aave.
   - Contract includes a payloads manager role with permission to create and cancel payloads.
   - Payload creation is permissioned: only the payloads manager can create payloads.
   - Contract has a guardian role to review created payloads and cancel them if incorrect or unrecognized.
-  - Only the owner can adjust the timelock within certain limits and rescue funds mistakenly sent.
+  - Only the owner can update payloadsManager, adjust the timelock within certain limits and rescue funds mistakenly sent.
   - Payloads manager and guardian have equal permissions to cancel payloads. Payloads can be cancelled if not expired or executed.
   - Payload execution is permissionless. If the timelock has passed and the payload isn't cancelled or expired, anyone can execute it. The Aave-robot is responsible for executing payloads.
 

--- a/docs/permissioned-payloads-controller-overview.md
+++ b/docs/permissioned-payloads-controller-overview.md
@@ -1,20 +1,19 @@
 ## Permissioned payloads controller overview
 
-[PermissionedPayloadsController](/src/contracts/payloads/PermissionedPayloadsController.sol): This is an extension of the PayloadsController contract, that modifies it so that only accepted actors (PayloadManager) can register a payload. The objective of having such extension is so that allowed third parties  to affect change into low risk parts of the protocol, using similar processeces as governance. For that a new Executor contract will be registered to this Permissioned Payloads Controller, that will hold limited permissions.
-At launch it will have permissions to change the LM programs.
-    
+[PermissionedPayloadsController](/src/contracts/payloads/PermissionedPayloadsController.sol): This is an extension of the PayloadsController contract, that modifies it so that only accepted actors (PayloadManager) can register a payload. The objective of having such extension is so that allowed third parties to affect change into low risk parts of the protocol, using similar processes as governance. For that a new Executor contract will be registered to this Permissioned Payloads Controller, that will hold limited permissions.
+At launch it will have permissions to change the LM programs for Aave.
+
   **Key points and differences from PayloadsController**:
-    
+
   - Contract includes a payloads manager role with permission to create and cancel payloads.
   - Payload creation is permissioned: only the payloads manager can create payloads.
   - Contract has a guardian role to review created payloads and cancel them if incorrect or unrecognized.
-  - The guardian can adjust the timelock within certain limits.
+  - Only the owner can adjust the timelock within certain limits and rescue funds mistakenly send.
   - Payloads manager and guardian have equal permissions to cancel payloads. Payloads can be cancelled if not expired or executed.
   - Payload execution is permissionless. If the timelock has passed and the payload isn't cancelled or expired, anyone can execute it. The Aave-robot is responsible for executing payloads.
-  - Executor holds permission emission admin role.
-    
+
   **The execution process operates as follows**:
-    
+
   1. A trusted entity creates a payload of any kind and submits it to the permissioned payloads controller.
   2. Payload creation is combined with queuing: once created, a payload is automatically queued. The payload ID returned from the createPayload() function can be used to cancel or execute the payload.
   3. The payload is assigned a timelock. During this timelock period, the guardian can verify the validity of the payload. If the payload is deemed invalid or unrecognized, the guardian can cancel it. The payloads manager also has the authority to cancel it.

--- a/docs/permissioned-payloads-controller-overview.md
+++ b/docs/permissioned-payloads-controller-overview.md
@@ -8,7 +8,7 @@ At launch it will have permissions to change the LM programs for Aave.
   - Contract includes a payloads manager role with permission to create and cancel payloads.
   - Payload creation is permissioned: only the payloads manager can create payloads.
   - Contract has a guardian role to review created payloads and cancel them if incorrect or unrecognized.
-  - Only the owner can adjust the timelock within certain limits and rescue funds mistakenly send.
+  - Only the owner can adjust the timelock within certain limits and rescue funds mistakenly sent.
   - Payloads manager and guardian have equal permissions to cancel payloads. Payloads can be cancelled if not expired or executed.
   - Payload execution is permissionless. If the timelock has passed and the payload isn't cancelled or expired, anyone can execute it. The Aave-robot is responsible for executing payloads.
 

--- a/security/certora/confs/payloads/verifyPayloadsController.conf
+++ b/security/certora/confs/payloads/verifyPayloadsController.conf
@@ -17,7 +17,7 @@
 //    "prover_args": [" -smt_LIASolvers [z3:def,z3:lia1,z3:lia2] -smt_NIASolvers [z3:def]"    ],
     "prover_args": ["-depth 0"],
     "smt_timeout": "6000",
-    "build_cache": true,
+    //"build_cache": true,
     "solc": "solc8.20",
     //"rule_sanity": "advanced",
     "verify": "PayloadsControllerHarness:security/certora/specs/payloads/PayloadsController.spec"

--- a/security/certora/confs/payloads/verifyPermissionedPayloadsController.conf
+++ b/security/certora/confs/payloads/verifyPermissionedPayloadsController.conf
@@ -16,7 +16,7 @@
 //    "prover_args": [" -smt_LIASolvers [z3:def,z3:lia1,z3:lia2] -smt_NIASolvers [z3:def]"    ],
     "prover_args": ["-depth 0"],
     "smt_timeout": "6000",
-    "build_cache": true,
+    //"build_cache": true,
     "solc": "solc8.20",
 //    "rule_sanity": "basic",
     "parametric_contracts":["PermissionedPayloadsControllerHarness"],

--- a/security/certora/confs/verifyGovernance.conf
+++ b/security/certora/confs/verifyGovernance.conf
@@ -36,6 +36,6 @@
     //],
 //    "disable_auto_cache_key_gen" :true,
     //"rule_sanity": "advanced",
-    "build_cache": true,
+    //"build_cache": true,
     "msg": "All Governance rules",
 }

--- a/security/certora/confs/verifyGovernancePowerStrategy.conf
+++ b/security/certora/confs/verifyGovernancePowerStrategy.conf
@@ -28,6 +28,6 @@
     "solc": "solc8.20",
     "smt_timeout": "6000",
     "rule_sanity": "basic",
-    "build_cache": true,
+    //"build_cache": true,
     "msg": "GovernancePowerStrategy tests"
 }

--- a/security/certora/confs/verifyVotingStrategy_unittests.conf
+++ b/security/certora/confs/verifyVotingStrategy_unittests.conf
@@ -18,6 +18,6 @@
     "loop_iter": "3",  // Needs 2 for isTokenSlotAccepted (A_AAVE uses 2 slots)
     "solc": "solc8.20",
     "rule_sanity": "basic",
-    "build_cache": true,
+    //"build_cache": true,
     "msg": "VotingStrategy tests"
 }

--- a/security/certora/confs/voting/verifyLegality.conf
+++ b/security/certora/confs/voting/verifyLegality.conf
@@ -35,7 +35,7 @@
 	    "VotingStrategyHarness",
 	    "CrossChainController"
     ],
-    "build_cache": true,
+    //"build_cache": true,
     "rule_sanity": "basic",
     "msg": "VotingMachine - legality rules"
 }

--- a/security/certora/confs/voting/verifyMisc.conf
+++ b/security/certora/confs/voting/verifyMisc.conf
@@ -35,7 +35,7 @@
         "VotingStrategyHarness",
         "CrossChainController"
     ],
-    "build_cache": true,
+    //"build_cache": true,
     "smt_timeout": "6000",
     "rule_sanity": "basic",
     "msg": "VotingMachine - miscellaneous rules"

--- a/security/certora/confs/voting/verifyPower_summary.conf
+++ b/security/certora/confs/voting/verifyPower_summary.conf
@@ -35,6 +35,6 @@
     ],
     // NOTE: not using sanity since onlyThreeTokens fails sanity on being tautologucal
     //"rule_sanity": "basic",
-    "build_cache": true,
+    //"build_cache": true,
     "msg": "VotingMachine setup - basic tests"
 }

--- a/security/certora/confs/voting/verifyProposal_config.conf
+++ b/security/certora/confs/voting/verifyProposal_config.conf
@@ -36,6 +36,6 @@
         "CrossChainController"
     ],
     "rule_sanity": "basic",
-    "build_cache": true,
+    //"build_cache": true,
     "msg": "VotingMachine - proposal configuration"
 }

--- a/security/certora/confs/voting/verifyProposal_states.conf
+++ b/security/certora/confs/voting/verifyProposal_states.conf
@@ -36,6 +36,6 @@
         "CrossChainController"
     ],
     "rule_sanity": "basic",
-    "build_cache": true,
+    //"build_cache": true,
     "msg": "VotingMachine - proposal states"
 }

--- a/security/certora/confs/voting/verifyVoting_and_tally.conf
+++ b/security/certora/confs/voting/verifyVoting_and_tally.conf
@@ -36,6 +36,6 @@
 	    "VotingStrategyHarness",
 	    "CrossChainController"
     ],
-    "build_cache": true,
+    //"build_cache": true,
     "msg": "VotingMachine - voting and tally rules"
 }

--- a/security/certora/scripts/run-all-execution.sh
+++ b/security/certora/scripts/run-all-execution.sh
@@ -1,8 +1,10 @@
 #CMN="--compilation_steps_only"
 
-
+echo "******** Running:  execution - 1 ***************"
+certoraRun $CMN security/certora/confs/payloads/verifyPermissionedPayloadsController.conf \
+           --msg "execution - 1"
 
            
-echo "******** Running:  execution - all rules ***************"
+echo "******** Running:  execution - 2 ***************"
 certoraRun $CMN security/certora/confs/payloads/verifyPayloadsController.conf  --rule payload_maximal_access_level_gt_action_access_level state_cant_decrease no_transition_beyond_state_gt_3 no_transition_beyond_state_variable_gt_3 no_queue_after_expiration empty_actions_if_out_of_bound_payload expirationTime_equal_to_createAt_plus_EXPIRATION_DELAY empty_actions_iff_uninitialized null_access_level_if_out_of_bound_payload null_creator_and_zero_expiration_time_if_out_of_bound_payload empty_actions_only_if_uninitialized_payload executor_access_level_within_range consecutiveIDs empty_actions_if_uninitialized_payload queued_before_expiration_delay payload_grace_period_eq_global_grace_period null_access_level_only_if_out_of_bound_payload null_state_variable_if_out_of_bound_payload created_in_the_past queued_after_created executed_after_queue queuedAt_is_zero_before_queued no_early_cancellation execute_before_delay__maximumAccessLevelRequired action_immutable_fixed_size_fields initialized_payload_fields_are_immutable payload_fields_immutable_after_createPayload method_reachability executor_exists_if_action_not_null executor_exists_only_if_action_not_null  payload_delay_within_range  delay_of_executor_of_max_access_level_within_range  nonempty_actions  executor_exists_iff_action_not_null  null_access_level_iff_state_is_none  executor_of_maximumAccessLevelRequired_exists  executor_of_maximumAccessLevelRequired_exists_after_createPayload   action_access_level_isnt_null_after_createPayload  executor_exists_after_createPayload  action_callData_immutable  action_signature_immutable  action_immutable_check_only_fixed_size_fields  zero_executedAt_if_not_executed  executor_isnt_used_twice executor_of_level_null_is_zero  executed_after_queue_state_variable zero_executedAt_if_not_executed_state_variable  queuedAt_is_zero_before_queued_state_variable executedAt_is_zero_before_executed_state_variable null_state_equivalence  executedAt_is_zero_before_executed  executed_when_in_queued_state executed_when_in_queued_state_variable guardian_can_cancel no_late_cancel state_variable_cant_decrease  checkUpdateExecutors checkUpdateExecutors_witness_1 checkUpdateExecutors_witness_2 checkUpdateExecutors_witness_3 checkUpdateExecutors_witness_4  payload_state_transition_post_state payload_state_transition_pre_state \
-           --msg "execution - all rules"
+           --msg "execution - 2"

--- a/security/certora/scripts/run-all-voting.sh
+++ b/security/certora/scripts/run-all-voting.sh
@@ -9,9 +9,12 @@ certoraRun $CMN security/certora/confs/voting/verifyLegality.conf \
            
 
 echo "******** Running:  voting:2  ***************"
-certoraRun $CMN security/certora/confs/voting/verifyMisc.conf \
-            \
-           --msg "voting 2: "
+certoraRun $CMN security/certora/confs/voting/verifyMisc.conf --exclude_rule submitTripleProofVerification \
+           --msg "voting 2: EXCLUDING: submitTripleProofVerification"
+
+echo "******** Running:  voting:2a  ***************"
+certoraRun $CMN security/certora/confs/voting/verifyMisc.conf --rule submitTripleProofVerification \
+           --msg "voting 2a: submitTripleProofVerification"
 
 
 echo "******** Running:  voting:3  ***************"
@@ -49,4 +52,10 @@ certoraRun $CMN security/certora/confs/voting/verifyVoting_and_tally.conf \
 
 echo "******** Running:  voting:8  ***************"
 certoraRun $CMN security/certora/confs/voting/verifyVoting_and_tally.conf \
-            --rule cannot_vote_twice_with_submitVoteAsRepresentative_and_submitVote \
+           --rule cannot_vote_twice_with_submitVoteAsRepresentative_and_submitVote \
+           --msg "voting 8: "
+
+echo "******** Running:  voting:9  ***************"
+certoraRun $CMN security/certora/confs/voting/verifyVoting_and_tally.conf \
+           --rule cannot_vote_twice_with_submitVoteSingleProofAsRepresentative_and_submitVote \
+           --msg "voting 9: "

--- a/security/certora/specs/payloads/PermissionedPayloadsController.spec
+++ b/security/certora/specs/payloads/PermissionedPayloadsController.spec
@@ -957,6 +957,7 @@ rule payload_state_transition_pre_state(method f) filtered {f ->
 rule method_reachability(method f) filtered {f ->
     f.contract == currentContract 
     && f.selector != sig:initialize(address,address,IPayloadsControllerCore.UpdateExecutorInput[]).selector
+    && f.selector != sig:initialize(address,address,address,IPayloadsControllerCore.UpdateExecutorInput[]).selector
     && f.selector != sig:updateExecutors(IPayloadsControllerCore.UpdateExecutorInput[]).selector
     }
 {
@@ -1016,7 +1017,7 @@ rule executorConfig_cant_change_except_delay1(method f) filtered {f->
 }
 
 
-rule only_guardian_can_change_delay1(method f) filtered {f->
+rule only_owner_can_change_delay1(method f) filtered {f->
     !f.isView && !is_reverting_func(f)
     } {
   uint40 delay1_before = getExecutorSettingsByAccessControl(PayloadsControllerUtils.AccessControl.Level_1).delay;
@@ -1027,7 +1028,7 @@ rule only_guardian_can_change_delay1(method f) filtered {f->
 
   uint40 delay1_after = getExecutorSettingsByAccessControl(PayloadsControllerUtils.AccessControl.Level_1).delay;
 
-  assert delay1_after != delay1_before => e.msg.sender== guardian() ;
+  assert delay1_after != delay1_before => e.msg.sender== owner() ;
 }
 
 

--- a/src/contracts/payloads/PermissionedPayloadsController.sol
+++ b/src/contracts/payloads/PermissionedPayloadsController.sol
@@ -13,10 +13,10 @@ import {Errors} from '../libraries/Errors.sol';
  * @author BGD Labs
  * @notice this contract contains the logic to execute payloads
  * without governance cycle but leaving the gap to review and cancel payloads.
- * @dev this contract is permissioned, only the payloads manager can create
- * and queue payloads. Also, not only guardian but also the payloads manager can cancel payloads.
+ * @dev this contract is permissioned, only the payloads manager can create and queue payloads.
+ * @dev owner has the permission to update the execution delay and rescue.
+ * @dev guardian has the permission to cancel payload, along with the payloads manager.
  * @dev constants were adjusted as the governance cycle is no longer needed.
- * @dev owner and guardian are the same entity here.
  */
 contract PermissionedPayloadsController is
   PayloadsControllerCore,
@@ -25,15 +25,15 @@ contract PermissionedPayloadsController is
 {
   /// @inheritdoc IPermissionedPayloadsController
   function initialize(
+    address owner,
     address guardian,
     address initialPayloadsManager,
     UpdateExecutorInput[] calldata executors
   )
     public
-    override(PayloadsControllerCore, IPermissionedPayloadsController)
     initializer
   {
-    PayloadsControllerCore.initialize(guardian, guardian, executors);
+    PayloadsControllerCore.initialize(owner, guardian, executors);
     _updatePayloadsManager(initialPayloadsManager);
   }
 
@@ -101,7 +101,7 @@ contract PermissionedPayloadsController is
    * @notice Sets the execution delay
    * @param delay The new execution delay to be set
    */
-  function setExecutionDelay(uint40 delay) external onlyGuardian {
+  function setExecutionDelay(uint40 delay) external onlyOwner {
     require(
       delay >= MIN_EXECUTION_DELAY() && delay <= MAX_EXECUTION_DELAY(),
       Errors.INVALID_EXECUTOR_DELAY

--- a/src/contracts/payloads/WithPayloadsManager.sol
+++ b/src/contracts/payloads/WithPayloadsManager.sol
@@ -42,7 +42,7 @@ contract WithPayloadsManager is OwnableWithGuardian, IWithPayloadsManager {
   /// @inheritdoc IWithPayloadsManager
   function updatePayloadsManager(
     address newPayloadsManager
-  ) external onlyOwnerOrGuardian {
+  ) external onlyOwner {
     _updatePayloadsManager(newPayloadsManager);
   }
 

--- a/src/contracts/payloads/interfaces/IPermissionedPayloadsController.sol
+++ b/src/contracts/payloads/interfaces/IPermissionedPayloadsController.sol
@@ -10,14 +10,16 @@ import {PayloadsControllerUtils} from "../PayloadsControllerUtils.sol";
  * @author BGD Labs
  * @notice interface containing the objects, events and methods definitions of the IPermissionedPayloadsController contract
  */
-interface IPermissionedPayloadsController is IPayloadsControllerCore, IWithPayloadsManager {  
+interface IPermissionedPayloadsController is IPayloadsControllerCore, IWithPayloadsManager {
   /**
    * @notice method to initialize the contract with starter params. Only callable by proxy
-   * @param guardian address of the guardian. With permissions to call certain methods
-   * @param initialPayloadsManager address of the initial payload manager
+   * @param owner address of the owner. With permission to change the delay and rescue
+   * @param guardian address of the guardian. With permission to cancel payloads
+   * @param initialPayloadsManager address of the initial payload manager. With permission to create payloads
    * @param executors array of executor configurations
    */
   function initialize(
+    address owner,
     address guardian,
     address initialPayloadsManager,
     UpdateExecutorInput[] calldata executors

--- a/tests/payloads/PermissionedPayloadsController.t.sol
+++ b/tests/payloads/PermissionedPayloadsController.t.sol
@@ -234,6 +234,35 @@ contract PermissionedPayloadsControllerTest is Test {
     permissionedPayloadPortal.setExecutionDelay(newDelay);
   }
 
+  function testUpdatePayloadsManagerWithOwner(
+    address admin,
+    address guardian,
+    address payloadsManager,
+    address origin
+  ) external initializeTest(admin, guardian, payloadsManager, origin) {
+    address newPayloadsManager = address(555);
+
+    vm.startPrank(Ownable(address(permissionedPayloadPortal)).owner());
+    permissionedPayloadPortal.updatePayloadsManager(newPayloadsManager);
+    vm.stopPrank();
+
+    address currentPayloadsManager = permissionedPayloadPortal.payloadsManager();
+    assertEq(currentPayloadsManager, newPayloadsManager, 'Payloads Manager was not set correctly');
+  }
+
+  function testUpdatePayloadsManagerWithInvalidCaller(
+    address admin,
+    address guardian,
+    address payloadsManager,
+    address origin
+  ) external initializeTest(admin, guardian, payloadsManager, origin) {
+    address newPayloadsManager = address(555);
+
+    vm.assume(origin != Ownable(address(permissionedPayloadPortal)).owner());
+    vm.expectRevert(bytes(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, origin)));
+    permissionedPayloadPortal.updatePayloadsManager(newPayloadsManager);
+  }
+
   function _createPayload(address caller) internal returns (uint40) {
     return _createPayload(caller, address(123));
   }


### PR DESCRIPTION
Currently we allow the guardian, to change the delay on permissioned-payloads-controller.
The idea initially was to keep a different entity than payloads-manager which can change the delay.

The guardian should be only allowed to cancel payloads and nothing else, so for better granularity we now allow the owner to change the executionDelay.

_Please note: earlier, the guardian and owner were the same entity, but now they will be different._

Roles:

- PayloadsManager: can create payloads
- Owner: can change executionDelay and rescue funds. (ideally owner should be the executor lvl1)
- Guardian: can cancel payloads